### PR TITLE
Replace Airtable API key with personal access token

### DIFF
--- a/src/components/applications/allApplications.jsx
+++ b/src/components/applications/allApplications.jsx
@@ -11,13 +11,25 @@ const AllApplications = (props) => {
 
     const getAllApplications = async () => {
         if (allApplications.length == 0) {
-            const responses = await fetch(global.APPLICATIONS_URL + `?api_key=${AIRTABLE_KEY}&view=Grid%20view`)
+            const responses = await fetch(global.APPLICATIONS_URL + `?view=Grid%20view`,
+                {
+                    headers: {
+                        Authorization: "Bearer " + AIRTABLE_KEY,
+                    },
+                }
+            )
                 .then(handleErrors)
 
             var offset = responses.offset;
             var collectedApplications = responses.records;
             while (offset != null) {
-                const offset_responses = await fetch(global.APPLICATIONS_URL + `?api_key=${AIRTABLE_KEY}&view=Grid%20view&offset=${offset}`)
+                const offset_responses = await fetch(global.APPLICATIONS_URL + `?view=Grid%20view&offset=${offset}`,
+                    {
+                        headers: {
+                            Authorization: "Bearer " + AIRTABLE_KEY,
+                        },
+                    }
+                )
                     .then(handleErrors);
                     collectedApplications = collectedApplications.concat(offset_responses.records);
                 offset = offset_responses.offset;

--- a/src/components/applications/application.jsx
+++ b/src/components/applications/application.jsx
@@ -100,12 +100,24 @@ const Application = (props) => {
   };
 
   const getApplicationsData = async (officers, decisions) => {    
-    const responses = await fetch(global.APPLICATIONS_URL + `?api_key=${AIRTABLE_KEY}&view=Grid%20view`)
+    const responses = await fetch(global.APPLICATIONS_URL + `?view=Grid%20view`,
+        {
+            headers: {
+                Authorization: "Bearer " + AIRTABLE_KEY,
+            },
+        }
+    )
       .then(handleErrors)
 
     const offset = responses.offset;
 
-    await fetch(global.APPLICATIONS_URL + `?api_key=${AIRTABLE_KEY}&view=Grid%20view&offset=${offset}`)
+    await fetch(global.APPLICATIONS_URL + `?view=Grid%20view&offset=${offset}`,
+        {
+            headers: {
+                Authorization: "Bearer " + AIRTABLE_KEY,
+            },
+        }
+    )
       .then(handleErrors)
       .then((result) => {
         const pageOne = responses.records;

--- a/src/components/update/update.jsx
+++ b/src/components/update/update.jsx
@@ -76,19 +76,31 @@ const Update = (props) => {
 
   React.useEffect(
     () => {
-        fetch(global.DECISIONS_URL + `/${decisionId}?api_key=${AIRTABLE_KEY}`)
-        .then(handleErrors)
-        .then((decision) => {
-            fetch(global.APPLICATIONS_URL + `/${decision.fields["ID"]}?api_key=${AIRTABLE_KEY}`)
-                .then(handleErrors)
-                .then((application) =>{
-                    setDecisionContent(decision);
-                    setApplicationContent(application);
-                    setFlag(decision.fields.Flag);
-                    setVote(decision.fields.Interview);
-                    setComments(decision.fields.Comments);
-                });
-        });
+        fetch(global.DECISIONS_URL + `/${decisionId}`,
+          {
+            headers: {
+              Authorization: "Bearer " + AIRTABLE_KEY,
+            },
+          }
+        )
+          .then(handleErrors)
+          .then((decision) => {
+            fetch(global.APPLICATIONS_URL + `/${decision.fields["ID"]}`,
+              {
+                headers: {
+                  Authorization: "Bearer " + AIRTABLE_KEY,
+                },
+              }
+            )
+              .then(handleErrors)
+              .then((application) =>{
+                setDecisionContent(decision);
+                setApplicationContent(application);
+                setFlag(decision.fields.Flag);
+                setVote(decision.fields.Interview);
+                setComments(decision.fields.Comments);
+              });
+          });
     }, [])
 
   const voteYesColor = vote == "Yes" ? "#9AFFB0" : "";

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -6,7 +6,11 @@ import { QUESTION_ORDER } from "../secrets";
  * @param {Object} entry: field response to be formatted (can be string or Object[])
  */
 export const formatFieldResponse = (entry) => {
-  return (typeof entry !== "string" && typeof entry !== "number") ? Array.from(entry).join(", ") : entry;
+  try{
+    return (typeof entry !== "string" && typeof entry !== "number") ? Array.from(entry).join(", ") : entry;
+  } catch (err) {
+    return `Encountered error while parsing application responses: ${err}`
+  }
 };
 
 /**


### PR DESCRIPTION
Airtable recently deprecated API keys in favor of personal access tokens and OAuth. This PR replaces all uses of API keys as URL keys and instead adds the secret key to the authorization headers.

See Airtable message
> API keys will be deprecated by the end of January 2024
> 
> After this date, API keys will stop working and you will have to migrate to personal access tokens. Personal access tokens allow you to more securely grant API access to Airtable data. [Learn more](https://support.airtable.com/docs/airtable-api-key-deprecation-notice)

Also fixes bug where app would crash when there are less than 2 pages of applicant entries. Now, we will only fetch the second page when the first response indicates there are more entries.